### PR TITLE
Rust bindings runtime configurable

### DIFF
--- a/.github/workflows/csharp-tests.yml
+++ b/.github/workflows/csharp-tests.yml
@@ -30,17 +30,16 @@ jobs:
             host: ubuntu-22.04
             ext: .so
             reqs: sudo apt update && sudo apt install -y clang binutils-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross crossbuild-essential-arm64
-          - arch: arm64-darwin
+          - arch: arm64-apple-macos11
             location: osx-arm64
             host: macos-latest
-            ext: .so
+            ext: .dylib
             reqs:
           - arch: x86_64-darwin
             location: osx-x64
             host: macos-latest
-            ext: .so
+            ext: .dylib
             reqs:
-          #TODO: support arch: x86_64-v2-win
           - arch:
             location: win-x64
             host: windows-latest

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ analysis-report/
 .idea/
 *bindings/*/*.so
 *bindings/rust/target
-*bindings/csharp/*.exe
-*bindings/csharp/*.dll
 __pycache__
 .DS_Store
 

--- a/bindings/csharp/.gitignore
+++ b/bindings/csharp/.gitignore
@@ -10,3 +10,5 @@ Ckzg.Bindings/runtimes/*/native/*
 test_ckzg*
 *.so
 *.dll
+*.exe
+*.dylib

--- a/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
+++ b/bindings/csharp/Ckzg.Bindings/Ckzg.Bindings.csproj
@@ -32,10 +32,12 @@
 
 	<ItemGroup>
 		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/win-x64/native/ckzg.dll')" Include="runtimes/win-x64/native/ckzg.dll" Pack="true" PackagePath="runtimes/win-x64/native/ckzg.dll" />
+		
 		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-x64/native/ckzg.so')" Include="runtimes/linux-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-x64/native/ckzg.so" />
 		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/linux-arm64/native/ckzg.so')" Include="runtimes/linux-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/linux-arm64/native/ckzg.so" />
-		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-x64/native/ckzg.so')" Include="runtimes/osx-x64/native/ckzg.so" Pack="true" PackagePath="runtimes/osx-x64/native/ckzg.so" />
-		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-arm64/native/ckzg.so')" Include="runtimes/osx-arm64/native/ckzg.so" Pack="true" PackagePath="runtimes/osx-arm64/native/ckzg.so" />
+
+		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-x64/native/ckzg.dylib')" Include="runtimes/osx-x64/native/ckzg.dylib" Pack="true" PackagePath="runtimes/osx-x64/native/ckzg.dylib" />
+		<Content CopyToOutputDirectory="PreserveNewest" Condition="Exists('runtimes/osx-arm64/native/ckzg.dylib')" Include="runtimes/osx-arm64/native/ckzg.dylib" Pack="true" PackagePath="runtimes/osx-arm64/native/ckzg.dylib" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/bindings/csharp/Makefile
+++ b/bindings/csharp/Makefile
@@ -7,7 +7,8 @@ ifeq ($(OS),Windows_NT)
 	BLST_OBJ = blst.lib
 	LOCATION ?= win-x64
 	CLANG_EXECUTABLE = clang
-	CKZG_LIBRARY_PATH = Ckzg.Bindings\runtimes\$(LOCATION)\native\ckzg.dll
+	EXTENSION ?= ".dll"
+	CKZG_LIBRARY_PATH = Ckzg.Bindings\runtimes\$(LOCATION)\native\ckzg$(EXTENSION)
 	CFLAGS += -Wl,/def:ckzg.def
 else
 	BLST_BUILDSCRIPT = ./build.sh
@@ -18,6 +19,7 @@ else
 	UNAME_S := $(shell uname -s)
 	UNAME_M := $(shell uname -m)
 	ifeq ($(UNAME_S),Linux)
+		EXTENSION ?= ".so"
 		ifeq ($(UNAME_M),x86_64)
 			LOCATION ?= linux-x64
 		else
@@ -25,6 +27,7 @@ else
 		endif
 	endif
 	ifeq ($(UNAME_S),Darwin)
+		EXTENSION ?= ".dylib"
 		ifeq ($(UNAME_M),arm64)
 			LOCATION ?= osx-arm64
 		else
@@ -32,7 +35,7 @@ else
 		endif
 	endif
 
-	CKZG_LIBRARY_PATH = Ckzg.Bindings/runtimes/$(LOCATION)/native/ckzg.so
+	CKZG_LIBRARY_PATH = Ckzg.Bindings/runtimes/$(LOCATION)/native/ckzg$(EXTENSION)
 endif
 
 FIELD_ELEMENTS_PER_BLOB ?= 4096

--- a/bindings/csharp/README.md
+++ b/bindings/csharp/README.md
@@ -4,8 +4,9 @@ This directory contains C# bindings for the C-KZG-4844 library.
 
 ## Prerequisites
 
-These bindings require .NET 6.0 (not 7.0). This can be found here:
-* https://dotnet.microsoft.com/en-us/download/dotnet/6.0
+Build requires:
+- `clang` as a preferred build tool for the native wrapper of ckzg. On Windows, it's tested with clang from [Microsoft Visual Studio components](https://learn.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-170);
+- [.NET SDK](https://dotnet.microsoft.com/en-us/download) to build the bindings.
 
 ## Build & test
 

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -12,7 +12,7 @@ fn generate_random_field_element(rng: &mut ThreadRng) -> Bytes32 {
 }
 
 fn generate_random_blob(rng: &mut ThreadRng, s: &KzgSettings) -> Vec<u8> {
-    let mut arr: Vec<u8> = vec![0; s.bytes_per_blob()];
+    let mut arr = vec![0; s.bytes_per_blob()];
     rng.fill(&mut arr[..]);
     // Ensure that the blob is canonical by ensuring that
     // each field element contained in the blob is < BLS_MODULUS

--- a/bindings/rust/benches/kzg_benches.rs
+++ b/bindings/rust/benches/kzg_benches.rs
@@ -11,7 +11,7 @@ fn generate_random_field_element(rng: &mut ThreadRng) -> Bytes32 {
     arr.into()
 }
 
-fn generate_random_blob(rng: &mut ThreadRng, s: &KzgSettings) -> Blob {
+fn generate_random_blob(rng: &mut ThreadRng, s: &KzgSettings) -> Vec<u8> {
     let mut arr: Vec<u8> = vec![0; s.bytes_per_blob()];
     rng.fill(&mut arr[..]);
     // Ensure that the blob is canonical by ensuring that
@@ -19,7 +19,7 @@ fn generate_random_blob(rng: &mut ThreadRng, s: &KzgSettings) -> Blob {
     for i in 0..s.field_elements_per_blob() {
         arr[i * BYTES_PER_FIELD_ELEMENT] = 0;
     }
-    Blob::from_bytes(arr.as_slice(), s).unwrap()
+    arr
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
@@ -29,7 +29,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     assert!(trusted_setup_file.exists());
     let kzg_settings = Arc::new(KzgSettings::load_trusted_setup_file(trusted_setup_file).unwrap());
 
-    let blobs: Vec<Blob> = (0..max_count)
+    let blobs: Vec<Vec<u8>> = (0..max_count)
         .map(|_| generate_random_blob(&mut rng, &kzg_settings))
         .collect();
     let commitments: Vec<Bytes48> = blobs

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -385,7 +385,7 @@ impl KZGProof {
     }
 
     pub fn verify_blob_kzg_proof_batch(
-        blobs: &Vec<Vec<u8>>,
+        blobs: &[Vec<u8>],
         commitments_bytes: &[Bytes48],
         proofs_bytes: &[Bytes48],
         kzg_settings: &KZGSettings,
@@ -558,7 +558,7 @@ mod tests {
     };
 
     fn generate_random_blob(rng: &mut ThreadRng, s: &KZGSettings) -> Vec<u8> {
-        let mut arr: Vec<u8> = vec![0; s.bytes_per_blob()];
+        let mut arr = vec![0; s.bytes_per_blob()];
         rng.fill(&mut arr[..]);
         // Ensure that the blob is canonical by ensuring that
         // each field element contained in the blob is < BLS_MODULUS

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -212,6 +212,12 @@ impl Drop for KZGSettings {
 }
 
 impl Blob {
+    pub fn from_bytes_unsafe(bytes: &[u8]) -> Result<Self, Error> {
+        Ok(Self {
+            bytes: bytes.to_vec(),
+        })
+    }
+
     pub fn from_bytes(bytes: &[u8], s: &KZGSettings) -> Result<Self, Error> {
         if bytes.len() != s.bytes_per_blob() {
             return Err(Error::InvalidBytesLength(format!(
@@ -220,9 +226,7 @@ impl Blob {
                 bytes.len(),
             )));
         }
-        Ok(Self {
-            bytes: bytes.to_vec(),
-        })
+        Self::from_bytes_unsafe(bytes)
     }
 
     pub fn from_hex(hex_str: &str, s: &KZGSettings) -> Result<Self, Error> {

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -48,9 +48,14 @@ pub struct BlobGeneric<const BYTES_PER_BLOB: usize> {
 }
 
 #[derive(Debug)]
-pub struct KzgSettingsGeneric<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>(
+struct KzgSettingsGeneric<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>(
     KZGSettings,
 );
+
+pub type MainnetKzgSettings = KzgSettingsGeneric<FIELD_ELEMENTS_PER_BLOB_MAINNET, BYTES_PER_BLOB_MAINNET>;
+pub type MainnetBlob = BlobGeneric<BYTES_PER_BLOB_MAINNET>;
+pub type MinimalKzgSettings = KzgSettingsGeneric<FIELD_ELEMENTS_PER_BLOB_MINIMAL, BYTES_PER_BLOB_MINIMAL>;
+pub type MinimalBlob = BlobGeneric<BYTES_PER_BLOB_MINIMAL>;
 
 impl<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>
     KzgSettingsGeneric<FIELD_ELEMENTS_PER_BLOB, BYTES_PER_BLOB>

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -59,7 +59,7 @@ pub type MinimalKzgSettings =
     KzgSettingsGeneric<FIELD_ELEMENTS_PER_BLOB_MINIMAL, BYTES_PER_BLOB_MINIMAL>;
 pub type MinimalBlob = BlobGeneric<BYTES_PER_BLOB_MINIMAL>;
 
-trait KzgSettingsTrait {
+pub trait KzgSettingsTrait {
     type Blob;
 
     fn inner(&self) -> &KZGSettings;

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -48,7 +48,7 @@ pub struct BlobGeneric<const BYTES_PER_BLOB: usize> {
 }
 
 #[derive(Debug)]
-struct KzgSettingsGeneric<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>(
+pub struct KzgSettingsGeneric<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>(
     KZGSettings,
 );
 

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -52,21 +52,21 @@ pub struct KzgSettingsGeneric<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_
     KZGSettings,
 );
 
-pub type MainnetKzgSettings = KzgSettingsGeneric<FIELD_ELEMENTS_PER_BLOB_MAINNET, BYTES_PER_BLOB_MAINNET>;
+pub type MainnetKzgSettings =
+    KzgSettingsGeneric<FIELD_ELEMENTS_PER_BLOB_MAINNET, BYTES_PER_BLOB_MAINNET>;
 pub type MainnetBlob = BlobGeneric<BYTES_PER_BLOB_MAINNET>;
-pub type MinimalKzgSettings = KzgSettingsGeneric<FIELD_ELEMENTS_PER_BLOB_MINIMAL, BYTES_PER_BLOB_MINIMAL>;
+pub type MinimalKzgSettings =
+    KzgSettingsGeneric<FIELD_ELEMENTS_PER_BLOB_MINIMAL, BYTES_PER_BLOB_MINIMAL>;
 pub type MinimalBlob = BlobGeneric<BYTES_PER_BLOB_MINIMAL>;
 
 impl<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>
     KzgSettingsGeneric<FIELD_ELEMENTS_PER_BLOB, BYTES_PER_BLOB>
 {
-    /// The number of bytes in a blob.
-
-    fn inner(&self) -> &KZGSettings {
+    pub fn inner(&self) -> &KZGSettings {
         &self.0
     }
 
-    fn new(kzg_settings: KZGSettings) -> Result<Self, Error> {
+    pub fn new(kzg_settings: KZGSettings) -> Result<Self, Error> {
         if kzg_settings.field_elements_per_blob() != FIELD_ELEMENTS_PER_BLOB {
             return Err(Error::InvalidTrustedSetup("length mismatch".to_string()));
         }
@@ -82,7 +82,7 @@ impl<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>
     /// 65 # This is fixed and is used for providing multiproofs up to 64 field elements.
     /// `FIELD_ELEMENT_PER_BLOB` lines with each line containing a hex encoded g1 byte value.
     /// 65 lines with each line containing a hex encoded g2 byte value.
-    fn load_trusted_setup_file(trusted_setup_file: &Path) -> Result<Self, Error> {
+    pub fn load_trusted_setup_file(trusted_setup_file: &Path) -> Result<Self, Error> {
         let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file)?;
         Self::new(kzg_settings)
     }
@@ -91,7 +91,7 @@ impl<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>
     ///
     /// The `g1_bytes` and `g2_bytes` need to be extracted and parsed from a file
     /// and then passed into this function.
-    fn load_trusted_setup(
+    pub fn load_trusted_setup(
         g1_bytes: &[[u8; BYTES_PER_G1_POINT]],
         g2_bytes: &[[u8; BYTES_PER_G2_POINT]],
     ) -> Result<Self, Error> {
@@ -100,7 +100,7 @@ impl<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>
     }
 
     /// Return the `KzgCommitment` corresponding to the `Blob`.
-    fn blob_to_kzg_commitment(
+    pub fn blob_to_kzg_commitment(
         &self,
         blob: &BlobGeneric<BYTES_PER_BLOB>,
     ) -> Result<KZGCommitment, Error> {
@@ -120,7 +120,7 @@ impl<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>
     }
 
     /// Compute the `KZGProof` given the `Blob` at the point corresponding to field element `z`.
-    fn compute_kzg_proof(
+    pub fn compute_kzg_proof(
         &self,
         blob: &BlobGeneric<BYTES_PER_BLOB>,
         z_bytes: &Bytes32,
@@ -144,7 +144,7 @@ impl<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>
     }
 
     /// Compute the `KZGProof` given the `Blob` and `KzgCommitment`.
-    fn compute_blob_kzg_proof(
+    pub fn compute_blob_kzg_proof(
         &self,
         blob: &BlobGeneric<BYTES_PER_BLOB>,
         commitment_bytes: &Bytes48,
@@ -166,7 +166,7 @@ impl<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>
     }
 
     /// Verify a KZG proof claiming that `p(z) == y`.
-    fn verify_kzg_proof(
+    pub fn verify_kzg_proof(
         &self,
         commitment_bytes: &Bytes48,
         z_bytes: &Bytes32,
@@ -192,7 +192,7 @@ impl<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>
     }
 
     /// Given a blob and its proof, verify that it corresponds to the provided commitment.
-    fn verify_blob_kzg_proof(
+    pub fn verify_blob_kzg_proof(
         &self,
         blob: &BlobGeneric<BYTES_PER_BLOB>,
         commitment_bytes: &Bytes48,
@@ -217,7 +217,7 @@ impl<const FIELD_ELEMENTS_PER_BLOB: usize, const BYTES_PER_BLOB: usize>
 
     /// Given a list of blobs and blob KZG proofs, verify that they correspond to the
     /// provided commitments.
-    fn verify_blob_kzg_proof_batch(
+    pub fn verify_blob_kzg_proof_batch(
         &self,
         blobs: &[BlobGeneric<BYTES_PER_BLOB>],
         commitments_bytes: &[Bytes48],

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -551,6 +551,14 @@ impl KZGSettings {
 
         result
     }
+
+    pub fn field_elements_per_blob(&self) -> usize {
+        self.field_elements_per_blob as usize
+    }
+
+    pub fn bytes_per_blob(&self) -> usize {
+        self.bytes_per_blob as usize
+    }
 }
 
 impl Drop for KZGSettings {

--- a/bindings/rust/src/bindings/mod.rs
+++ b/bindings/rust/src/bindings/mod.rs
@@ -267,14 +267,14 @@ pub trait Kzg<const FIELD_ELEMENTS_PER_BLOB: usize> {
     }
 }
 
-struct MainnetKzg;
+pub struct MainnetKzg;
 impl Kzg<FIELD_ELEMENTS_PER_BLOB_MAINNET> for MainnetKzg {
     /// A basic blob data.
     type Blob = BlobGeneric<{ Self::BYTES_PER_BLOB }>;
     type KzgSettings = KzgSettingsGeneric<FIELD_ELEMENTS_PER_BLOB_MAINNET>;
 }
 
-struct MinimalKzg;
+pub struct MinimalKzg;
 impl Kzg<FIELD_ELEMENTS_PER_BLOB_MINIMAL> for MinimalKzg {
     /// A basic blob data.
     type Blob = BlobGeneric<{ Self::BYTES_PER_BLOB }>;

--- a/bindings/rust/src/bindings/serde.rs
+++ b/bindings/rust/src/bindings/serde.rs
@@ -1,6 +1,6 @@
 //! Serde serialization and deserialization for the basic types in this crate.
 
-use crate::{Blob, Bytes32, Bytes48};
+use crate::{Bytes32, Bytes48};
 use alloc::string::String;
 use alloc::vec::Vec;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
@@ -18,21 +18,6 @@ fn deserialize_hex<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>
     let s = String::deserialize(deserializer)?;
     let hex_bytes = s.strip_prefix("0x").unwrap_or(&s);
     hex::decode(hex_bytes).map_err(Error::custom)
-}
-
-impl Serialize for Blob {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serialize_bytes(self.bytes.as_slice(), serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for Blob {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Blob::from_bytes_unsafe(&deserialize_hex(deserializer)?).map_err(Error::custom)
-    }
 }
 
 impl Serialize for Bytes48 {

--- a/bindings/rust/src/bindings/serde.rs
+++ b/bindings/rust/src/bindings/serde.rs
@@ -55,8 +55,8 @@ mod tests {
     use super::super::*;
     use rand::{rngs::ThreadRng, Rng};
 
-    fn generate_random_blob(rng: &mut ThreadRng, s: &KZGSettings) -> Blob {
-        let mut arr: Vec<u8> = vec![0; s.bytes_per_blob()];
+    fn generate_random_blob(rng: &mut ThreadRng, s: &KZGSettings) -> Vec<u8> {
+        let mut arr = vec![0; s.bytes_per_blob()];
         rng.fill(&mut arr[..]);
         // Ensure that the blob is canonical by ensuring that
         // each field element contained in the blob is < BLS_MODULUS
@@ -90,7 +90,7 @@ mod tests {
 
         // check blob serialization
         let blob_serialized = serde_json::to_string(&blob).unwrap();
-        let blob_deserialized: Blob = serde_json::from_str(&blob_serialized).unwrap();
+        let blob_deserialized = serde_json::from_str(&blob_serialized).unwrap();
         assert_eq!(blob, blob_deserialized);
 
         // check commitment serialization

--- a/bindings/rust/src/bindings/serde.rs
+++ b/bindings/rust/src/bindings/serde.rs
@@ -72,17 +72,17 @@ impl<'de> Deserialize<'de> for Bytes32 {
 
 #[cfg(test)]
 mod tests {
-    use crate::kzg_mainnet::{Blob, Kzg, BYTES_PER_BLOB};
+    use crate::kzg_mainnet::{Blob, Kzg, BYTES_PER_BLOB, FIELD_ELEMENTS_PER_BLOB};
 
     use super::super::*;
     use rand::{rngs::ThreadRng, Rng};
 
-    fn generate_random_blob(rng: &mut ThreadRng, s: &KZGSettings) -> Blob {
+    fn generate_random_blob(rng: &mut ThreadRng) -> Blob {
         let mut arr = [0; BYTES_PER_BLOB];
         rng.fill(&mut arr[..]);
         // Ensure that the blob is canonical by ensuring that
         // each field element contained in the blob is < BLS_MODULUS
-        for i in 0..s.field_elements_per_blob() {
+        for i in 0..FIELD_ELEMENTS_PER_BLOB {
             arr[i * BYTES_PER_FIELD_ELEMENT] = 0;
         }
         Blob::new(arr)
@@ -101,11 +101,11 @@ mod tests {
         // load setup so we can create commitments and blobs
         let trusted_setup_file = trusted_setup_file();
         assert!(trusted_setup_file.exists());
-        let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
+        let kzg_settings = Kzg::load_trusted_setup_file(trusted_setup_file).unwrap();
 
         // generate blob, commitment, proof
         let mut rng = rand::thread_rng();
-        let blob = generate_random_blob(&mut rng, &kzg_settings);
+        let blob = generate_random_blob(&mut rng);
         let commitment = Kzg::blob_to_kzg_commitment(&blob, &kzg_settings).unwrap();
         let proof =
             Kzg::compute_blob_kzg_proof(&blob, &commitment.to_bytes(), &kzg_settings).unwrap();
@@ -132,11 +132,10 @@ mod tests {
         // load setup so we can create blobs
         let trusted_setup_file = trusted_setup_file();
         assert!(trusted_setup_file.exists());
-        let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
 
         // generate blob
         let mut rng = rand::thread_rng();
-        let blob = generate_random_blob(&mut rng, &kzg_settings);
+        let blob = generate_random_blob(&mut rng);
 
         // check blob serialization
         let blob_serialized = serde_json::to_string(&blob).unwrap();
@@ -156,11 +155,11 @@ mod tests {
         // load setup so we can create a commitments
         let trusted_setup_file = trusted_setup_file();
         assert!(trusted_setup_file.exists());
-        let kzg_settings = KZGSettings::load_trusted_setup_file(trusted_setup_file).unwrap();
+        let kzg_settings = Kzg::load_trusted_setup_file(trusted_setup_file).unwrap();
 
         // generate blob just to calculate a commitment
         let mut rng = rand::thread_rng();
-        let blob = generate_random_blob(&mut rng, &kzg_settings);
+        let blob = generate_random_blob(&mut rng);
         let commitment = Kzg::blob_to_kzg_commitment(&blob, &kzg_settings).unwrap();
 
         // check blob serialization

--- a/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error, KzgSettings};
+use crate::bindings::hex_to_bytes;
+use crate::{Bytes48, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -9,8 +10,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self, s: &KzgSettings) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob, s)
+    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
+        hex_to_bytes(self.blob)
     }
 }
 

--- a/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
+++ b/bindings/rust/src/bindings/test_formats/blob_to_kzg_commitment_test.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use crate::bindings::hex_to_bytes;
+use crate::kzg_mainnet::Blob;
 use crate::{Bytes48, Error};
 use serde::Deserialize;
 
@@ -10,8 +11,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
-        hex_to_bytes(self.blob)
+    pub fn get_blob(&self) -> Result<Blob, Error> {
+        Blob::from_bytes(&hex_to_bytes(self.blob).unwrap())
     }
 }
 

--- a/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error, KzgSettings};
+use crate::bindings::hex_to_bytes;
+use crate::{Bytes48, Error};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -10,8 +11,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self, s: &KzgSettings) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob, s)
+    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
+        hex_to_bytes(self.blob)
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {

--- a/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_blob_kzg_proof.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use crate::bindings::hex_to_bytes;
+use crate::kzg_mainnet::Blob;
 use crate::{Bytes48, Error};
 use serde::Deserialize;
 
@@ -11,8 +12,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
-        hex_to_bytes(self.blob)
+    pub fn get_blob(&self) -> Result<Blob, Error> {
+        Blob::from_bytes(&hex_to_bytes(self.blob).unwrap())
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {

--- a/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes32, Bytes48, Error, KzgSettings};
+use crate::{Bytes32, Bytes48, Error};
 use serde::Deserialize;
+use crate::bindings::hex_to_bytes;
 
 #[derive(Deserialize)]
 pub struct Input<'a> {
@@ -10,8 +11,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self, s: &KzgSettings) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob, s)
+    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
+        hex_to_bytes(self.blob)
     }
 
     pub fn get_z(&self) -> Result<Bytes32, Error> {

--- a/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/compute_kzg_proof.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
 
+use crate::bindings::hex_to_bytes;
+use crate::kzg_mainnet::Blob;
 use crate::{Bytes32, Bytes48, Error};
 use serde::Deserialize;
-use crate::bindings::hex_to_bytes;
 
 #[derive(Deserialize)]
 pub struct Input<'a> {
@@ -11,8 +12,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
-        hex_to_bytes(self.blob)
+    pub fn get_blob(&self) -> Result<Blob, Error> {
+        Blob::from_bytes(&hex_to_bytes(self.blob).unwrap())
     }
 
     pub fn get_z(&self) -> Result<Bytes32, Error> {

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error, KzgSettings};
+use crate::{Bytes48, Error};
 use serde::Deserialize;
+use crate::bindings::hex_to_bytes;
 
 #[derive(Deserialize)]
 pub struct Input<'a> {
@@ -11,8 +12,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self, s: &KzgSettings) -> Result<Blob, Error> {
-        Blob::from_hex(self.blob, s)
+    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
+        hex_to_bytes(self.blob)
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
 
+use crate::bindings::hex_to_bytes;
+use crate::kzg_mainnet::Blob;
 use crate::{Bytes48, Error};
 use serde::Deserialize;
-use crate::bindings::hex_to_bytes;
 
 #[derive(Deserialize)]
 pub struct Input<'a> {
@@ -12,8 +13,8 @@ pub struct Input<'a> {
 }
 
 impl Input<'_> {
-    pub fn get_blob(&self) -> Result<Vec<u8>, Error> {
-        hex_to_bytes(self.blob)
+    pub fn get_blob(&self) -> Result<Blob, Error> {
+        Blob::from_bytes(&hex_to_bytes(self.blob).unwrap())
     }
 
     pub fn get_commitment(&self) -> Result<Bytes48, Error> {

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
-use crate::{Blob, Bytes48, Error, KzgSettings};
+use crate::{Bytes48, Error};
 use serde::Deserialize;
+use crate::bindings::hex_to_bytes;
 
 #[derive(Deserialize)]
 pub struct Input {
@@ -11,10 +12,10 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn get_blobs(&self, s: &KzgSettings) -> Result<Vec<Blob>, Error> {
-        let mut v: Vec<Blob> = Vec::new();
+    pub fn get_blobs(&self) -> Result<Vec<Vec<u8>>, Error> {
+        let mut v: Vec<Vec<u8>> = Vec::new();
         for blob in &self.blobs {
-            v.push(Blob::from_hex(blob, s)?);
+            v.push(hex_to_bytes(blob)?);
         }
         Ok(v)
     }

--- a/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
+++ b/bindings/rust/src/bindings/test_formats/verify_blob_kzg_proof_batch.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
 
+use crate::bindings::hex_to_bytes;
+use crate::kzg_mainnet::Blob;
 use crate::{Bytes48, Error};
 use serde::Deserialize;
-use crate::bindings::hex_to_bytes;
 
 #[derive(Deserialize)]
 pub struct Input {
@@ -12,10 +13,11 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn get_blobs(&self) -> Result<Vec<Vec<u8>>, Error> {
-        let mut v: Vec<Vec<u8>> = Vec::new();
+    pub fn get_blobs(&self) -> Result<Vec<Blob>, Error> {
+        let mut v: Vec<Blob> = Vec::new();
         for blob in &self.blobs {
-            v.push(hex_to_bytes(blob)?);
+            let blob = Blob::from_bytes(&hex_to_bytes(blob).unwrap())?;
+            v.push(blob);
         }
         Ok(v)
     }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -21,4 +21,4 @@ pub use bindings::{
     BYTES_PER_PROOF,
 };
 // Expose the remaining relevant types.
-pub use bindings::{Blob, Bytes32, Bytes48, Error};
+pub use bindings::{Bytes32, Bytes48, Error};

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -11,9 +11,7 @@ extern crate blst;
 mod bindings;
 
 // Expose relevant types with idiomatic names.
-pub use bindings::{
-    kzg_mainnet, kzg_minimal, KZGCommitment as KzgCommitment, KZGProof as KzgProof,
-};
+pub use bindings::*;
 // Expose the constants.
 pub use bindings::{
     BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, BYTES_PER_G1_POINT, BYTES_PER_G2_POINT,

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -12,8 +12,8 @@ mod bindings;
 
 // Expose relevant types with idiomatic names.
 pub use bindings::{
-    KZGCommitment as KzgCommitment, KZGProof as KzgProof, KZGSettings as KzgSettings,
-    C_KZG_RET as CkzgError,
+    kzg_mainnet, kzg_minimal, KZGCommitment as KzgCommitment, KZGProof as KzgProof,
+    KZGSettings as KzgSettings,
 };
 // Expose the constants.
 pub use bindings::{

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -13,7 +13,6 @@ mod bindings;
 // Expose relevant types with idiomatic names.
 pub use bindings::{
     kzg_mainnet, kzg_minimal, KZGCommitment as KzgCommitment, KZGProof as KzgProof,
-    KZGSettings as KzgSettings,
 };
 // Expose the constants.
 pub use bindings::{


### PR DESCRIPTION
builds off @pawanjay176 's work, extending it to add a `GenericBlob` type (suggested by @kevaundray) that acts like what's described here: https://github.com/ethereum/c-kzg-4844/pull/363#issuecomment-1745590789 

kzg settings types:
- `MainnetKzgSettings` - only accepts `MainnetBlob` for verification
- `MinimalKzgSettings` - only accepts `MinimalBlob` for verification
- `MainnetKzgSettingsGeneric` - only accepts `GenericBlob` for verification, can produce `GenericBlob`'s and checks them with mainnet config
- `MinimalKzgSettingsGeneric` - only accepts `GenericBlob` for verification, can produce `GenericBlob`'s and checks them with minimal config

blob types:
- `MainnetBlob` - mainnet spec length check guarunteed by type, can be constructed without corresponding settings struct
- `MininalBlob`- minimal spec length check guarunteed by type, can be constructed without corresponding settings struct
- `GenericBlob` - can only be constructed by `MainnetKzgSettingsGeneric` or `MinimalKzgSettingsGeneric`, guarunteed to have been length checked by one of these


Currently the blob structs wrap either an array or a vec. There was some mention of something like `bytes::Bytes`, I can add that if we want. 
Also I haven't updated benches or tests or anything but can if there's interest in going this direction